### PR TITLE
Update Dockerfile CMake version

### DIFF
--- a/docker/Dockerfile.ubuntu20.04
+++ b/docker/Dockerfile.ubuntu20.04
@@ -18,7 +18,7 @@ RUN ln -nsf /usr/bin/tclsh8.6 /usr/bin/tclsh
 # Update Cmake
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /etc/apt/trusted.gpg.d/kitware.gpg
 RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
-    && apt-get update && apt-get install -y cmake
+    && apt-get update && apt-get install -y cmake-data=3.31.0-0kitware1ubuntu20.04.1 cmake=3.31.0-0kitware1ubuntu20.04.1
 
 RUN apt-get clean
 


### PR DESCRIPTION
Freezing CMake version to 3.31.0 (last 3.x release). Kitware recently released CMake 4.0.0 that [deprecated certain features](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features) which results in errors with building Dromajo during ``make prep_lite`` in the Docker container. 