### PR TITLE
README: point users to Dockerfile for system dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ And some lesser tested, maintenance operations
 
 ## Getting Started
 
+### System Dependencies
+
+The full list of required system packages is maintained in
+[docker/Dockerfile.ubuntu24.04](docker/Dockerfile.ubuntu24.04).
+
+If you are setting up the environment without Docker, you may need to install
+packages listed there manually. Commonly missing tools on fresh Ubuntu systems
+include:
+
+- help2man
+- cmake
+- gawk
+- texinfo
+
+If you encounter errors such as `help2man: command not found`,
+`cmake: command not found`, or `configure: error: GNU Awk not found`,
+install the corresponding package and rerun `make prep`.
+
+
 make prep is a meta-target which will build the RISC-V toolchains, programs and microcode.
 This will prepare everything needed for a full BlackParrot evaluation setup.
 Users who are changing code can use the targets in tagged submodules as appropriate.


### PR DESCRIPTION
While setting up the BlackParrot simulation environment on a fresh Ubuntu system,
I encountered several missing dependency errors during `make prep`.

The repository already maintains the authoritative list of required packages in
docker/Dockerfile.ubuntu24.04, but this is not obvious from the current README.

This PR adds a short "System Dependencies" note under the Getting Started section to:

1. Point users to docker/Dockerfile.ubuntu24.04 for the full list of required packages.
2. Clarify that users setting up without Docker may need to install packages from that file.
3. Mention common missing tools (help2man, cmake, gawk, texinfo) that often cause setup errors.

This avoids duplication while improving onboarding for contributors who set up the environment natively.

Fixes #31